### PR TITLE
Potential fix for code scanning alert no. 2: Replacement of a substring with itself

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
       '/api': {
         target: 'http://localhost:3000',
         changeOrigin: true,
-        rewrite: path => path.replace(/^\/api/, '/api'),
+        rewrite: path => path.replace(/^\/api/, ''),
       },
     },
   },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
       '/api': {
         target: 'http://localhost:3000',
         changeOrigin: true,
-        rewrite: path => path.replace(/^\/api/, ''),
+        rewrite: path => path.replace(/^\/api(\/|$)/, '/'),
       },
     },
   },


### PR DESCRIPTION
Potential fix for [https://github.com/SashaCarton/PortfolioPenelope/security/code-scanning/2](https://github.com/SashaCarton/PortfolioPenelope/security/code-scanning/2)

To fix the problem, the rewrite function should remove the `/api` prefix from the path, so that requests to `/api/foo` are proxied to `/foo` on the target server. This is typically done by replacing the `/api` prefix with an empty string. The code to change is on line 13 of `frontend/vite.config.ts`, specifically the replacement string in `path.replace(/^\/api/, '/api')`. It should be changed to `path.replace(/^\/api/, '')`. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
